### PR TITLE
Fixed blocking of course selection when input is null

### DIFF
--- a/lib/widgets/choosepage/menu.dart
+++ b/lib/widgets/choosepage/menu.dart
@@ -104,6 +104,7 @@ class MenuIconsState extends ConsumerState<MenuIcons> {
     return GestureDetector(
       onTap: () => {
         ref.watch(choosePageModeProvider.notifier).state = type,
+        ref.read(inputStringProvider.notifier).state = '',
       },
       child: Stack(
         children: [

--- a/lib/widgets/choosepage/showlist.dart
+++ b/lib/widgets/choosepage/showlist.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'dart:convert';
 import 'dart:async' show Future;
@@ -79,6 +81,7 @@ class ShowList extends ConsumerWidget {
     final chosenYear = ref.watch(chosenYearProvider);
     final chosenSeason = ref.watch(chosenSeasonProvider);
     final inputState = ref.watch(searchBoolProvider);
+    final inputString = ref.watch(inputStringProvider);
     final pageMode = ref.watch(choosePageModeProvider);
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
@@ -90,12 +93,13 @@ class ShowList extends ConsumerWidget {
                 Navigator.of(context).pop();
               })
             : inputState == false
-                ? save(
-                    '${chosenYear}_$chosenSeason', chosenTime, classInfo, ref,
-                    () {
-                    ref.watch(inputStringProvider.notifier).state = '';
-                    Navigator.of(context).pop();
-                  })
+                ? inputString == ''
+                    ? null
+                    : save('${chosenYear}_$chosenSeason', chosenTime, classInfo,
+                        ref, () {
+                        ref.watch(inputStringProvider.notifier).state = '';
+                        Navigator.of(context).pop();
+                      })
                 : null;
       },
       child: Container(


### PR DESCRIPTION
講義選択時にWidgetの状態が"Search"なら無条件で保存、それ以外の場合入力値がNullもしくは''の場合は選択時に保存を実行しないようにしてぬるぽしないように変更。メニューのモード切り替えをした時にSearchとEdit間で入力がつながってしまぅっていた問題も修正。